### PR TITLE
Fix AnswerInputView button title usage

### DIFF
--- a/PocketWords/Components/AnswerInputView.swift
+++ b/PocketWords/Components/AnswerInputView.swift
@@ -27,7 +27,7 @@ struct AnswerInputView: View {
                 .submitLabel(.send) // Changes the return key title to "Done"
             
             ActionButton(
-                title: "Check",
+                title: buttonTitle,
                 isSmallButton: true,
                 isEnabled: !userAnswer.isEmpty,
                 isLoading: false,


### PR DESCRIPTION
## Summary
- fix `AnswerInputView` to display the provided button title instead of a hardcoded label

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68454c40cd0c832aa608019300ef8767